### PR TITLE
Support anchors in the hash history

### DIFF
--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -17,7 +17,8 @@ export function removeEventListener(node, event, listener) {
 export function getHashPath() {
   // We can't use window.location.hash here because it's not
   // consistent across browsers - Firefox will pre-decode it!
-  return window.location.href.split('#')[1] || ''
+  let href = window.location.href
+  return href.indexOf('#') > -1 ? href.substring(href.indexOf('#') + 1) : ''
 }
 
 export function replaceHashPath(path) {

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -9,6 +9,7 @@ import describeReplaceState from './describeReplaceState'
 import describeReplace from './describeReplace'
 import describePopState from './describePopState'
 import describeQueryKey from './describeQueryKey'
+import describeHashSupport from './describeHashSupport'
 import describeBasename from './describeBasename'
 import describeQueries from './describeQueries'
 import describeGo from './describeGo'
@@ -25,6 +26,7 @@ describe('hash history', function () {
   describePush(createHashHistory)
   describeReplaceState(createHashHistory)
   describeReplace(createHashHistory)
+  describeHashSupport(createHashHistory)
   describeBasename(createHashHistory)
   describeQueries(createHashHistory)
 
@@ -49,5 +51,22 @@ describe('hash history', function () {
   it('knows how to make hrefs', function () {
     let history = createHashHistory()
     expect(history.createHref('/a/path')).toEqual('#/a/path')
+  })
+
+  it('serializes hash from location', function () {
+    let history = createHashHistory({ queryKey: false })
+    history.pushState(null, '/home?the=query#anchor')
+    expect(window.location.hash).toEqual('#/home?the=query#anchor')
+  })
+
+  it('reads hash from location', function (done) {
+    window.location.hash = '#/home#anchor'
+    let history = createHashHistory()
+    let unlisten = history.listen(function (location) {
+      expect(location.pathname).toEqual('/home')
+      expect(location.hash).toEqual('#anchor')
+      done()
+    })
+    unlisten()
   })
 })

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -88,12 +88,12 @@ function createHashHistory(options={}) {
   }
 
   function finishTransition(location) {
-    let { basename, pathname, search, state, action, key } = location
+    let { basename, pathname, search, hash, state, action, key } = location
 
     if (action === POP)
       return // Nothing to do.
 
-    let path = (basename || '') + pathname + search
+    let path = (basename || '') + pathname + search + hash
 
     if (queryKey) {
       path = addQueryStringValueToPath(path, queryKey, key)


### PR DESCRIPTION
Now `location.hash` is ignored when `createHashHistory` is used.

This fix makes the behavior of `createHashHistory` more compatible with `createBrowserHistory`.