### PR TITLE
Fix SCRIPT16389: Unspecified error. IE11 on page refresh

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -28,7 +28,7 @@ function createBrowserHistory(options={}) {
   function getCurrentLocation(historyState) {
     try {
       historyState = historyState || window.history.state || {}
-    } catch {
+    } catch (e) {
       historyState = {}
     }
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -26,7 +26,11 @@ function createBrowserHistory(options={}) {
   const useRefresh = !isSupported || forceRefresh
 
   function getCurrentLocation(historyState) {
-    historyState = historyState || window.history.state || {}
+    try {
+      historyState = historyState || window.history.state || {}
+    } catch {
+      historyState = {}
+    }
 
     const path = getWindowPath()
     let { key } = historyState


### PR DESCRIPTION
If there is no browser history in the window in IE11 the window.history.state throws an unspecified error. Wrap in try catch.
Similar issue found in Angular https://github.com/angular/angular.js/issues/10367