### PR TITLE
Fix history listener being called twice in Safari, basename being prepended twice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## HEAD
+> Mar 3, 2016
+
+- **Bugfix:** Fix history listener being called twice in Safari, basename being prepended twice ([#238])
+
 ## [v2.0.0]
 > Feb 4, 2016
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -49,7 +49,7 @@ function createBrowserHistory(options={}) {
 
   function startPopStateListener({ transitionTo }) {
     function popStateListener(event) {
-      if (event.state === undefined)
+      if (event.state === undefined || event.state === null)
         return // Ignore extraneous popstate events in WebKit.
 
       transitionTo(

--- a/modules/useBasename.js
+++ b/modules/useBasename.js
@@ -5,9 +5,8 @@ import deprecate from './deprecate'
 
 function useBasename(createHistory) {
   return function (options={}) {
-    const history = createHistory(options)
-
-    let { basename } = options
+    let { basename, ...historyOptions } = options
+    const history = createHistory(historyOptions)
 
     // Automatically use the value of <base href> in HTML
     // documents as basename if it's not explicitly given.


### PR DESCRIPTION
Fixes #238 , also:

useBasename.js ~L8 used to look like: 

```
let { basename, ...historyOptions } = options
let history = createHistory(historyOptions)
```

but was changed to 

```
const history = createHistory(options)
let { basename } = options
```

in this commit: https://github.com/mjackson/history/commit/816318f5b3f52153dfca3ba67bd55d4ee2858614

The two aren't equivalent, was this intentional? It's broken for me - causes the basename to prepended twice. Eg, my basename is `/dealer/platform/` and with the change above I'm taken to `/dealer/platform/dealer/platform/`
