### PR TITLE
Fix usage of hasOwnProperty

### DIFF
--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -14,7 +14,7 @@ const defaultParseQueryString = parse
 
 function isNestedObject(object) {
   for (const p in object)
-    if (object.hasOwnProperty(p) &&
+    if (Object.prototype.hasOwnProperty.call(object, p) &&
         typeof object[p] === 'object' &&
         !Array.isArray(object[p]) &&
         object[p] !== null)


### PR DESCRIPTION
Fixes #247.

This is the correct fix regardless of what `query-string` does upstream.

We need to merge this and release a new v2.0.2 unless `query-string` cuts a new release.