### PR TITLE
Get the navigator property from window

### DIFF
--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -16,7 +16,7 @@ export const removeEventListener = (node, event, listener) =>
  * changed to avoid false negatives for Windows Phones: https://github.com/reactjs/react-router/issues/586
  */
 export const supportsHistory = () => {
-  const ua = navigator.userAgent
+  const ua = window.navigator.userAgent
 
   if ((ua.indexOf('Android 2.') !== -1 || ua.indexOf('Android 4.0') !== -1) &&
     ua.indexOf('Mobile Safari') !== -1 &&
@@ -32,4 +32,4 @@ export const supportsHistory = () => {
  * Returns false if using go(n) with hash history causes a full page reload.
  */
 export const supportsGoWithoutReloadUsingHash = () =>
-  navigator.userAgent.indexOf('Firefox') === -1
+  window.navigator.userAgent.indexOf('Firefox') === -1


### PR DESCRIPTION
This simplifies mocking the window object when running server side tests.

In my particular use case this patch means that I can use React Router's `Link` by just mocking `global.window` with jsdom in Node. The alternatives are more complex mocks and require hooks, or assigning all/more properties from jsdom's `window` to the Node `global` object.