### PR TITLE
Update query-string major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "query-string": "^3.0.0",
+    "query-string": "^4.1.0",
     "warning": "^2.0.0"
   },
   "devDependencies": {
@@ -67,7 +67,12 @@
     "location"
   ],
   "babel": {
-    "presets": [ "es2015", "stage-1" ],
-    "plugins": [ "dev-expression" ]
+    "presets": [
+      "es2015",
+      "stage-1"
+    ],
+    "plugins": [
+      "dev-expression"
+    ]
   }
 }


### PR DESCRIPTION
This gives better deduping if users (like me!) are manually installing query-string.

I'm not adding this to the v2 branch (even though I want to have this change), because this brings back the (IMO correct) `Object.create(null)` behavior, and that's technically breaking, as we surface these objects back to the user.