### PR TITLE
namespace global name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const webpack = require('webpack')
 module.exports = {
 
   output: {
-    library: 'History',
+    library: '_History',
     libraryTarget: 'umd'
   },
 


### PR DESCRIPTION
So it doesn't clash with the built-in [History](https://developer.mozilla.org/en-US/docs/Web/API/History) api.

I'm sure everyone will hate this. I'm just not sure what to name it, so this is a place to have a discussion about what to call it.