### PR TITLE
call getCurrentIndex before reassigning currentLocation

### DIFF
--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -35,9 +35,9 @@ const createHistory = (options = {}) => {
   }
 
   const updateLocation = (nextLocation) => {
-    currentLocation = nextLocation
-
     const currentIndex = getCurrentIndex()
+
+    currentLocation = nextLocation
 
     if (currentLocation.action === PUSH) {
       allKeys = [ ...allKeys.slice(0, currentIndex + 1), currentLocation.key ]


### PR DESCRIPTION
calls to `getCurrentIndex` always return `-1` because `currentLocation` is being reassigned before lookup. this fixes behavior for restoring the url on canceled transitions (without a refresh).