### PR TITLE
Fix #295: Hash history fails to save state on IE 11 when served over file protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,12 @@
 
 - `location.query` has no prototype
 - Warn about protocol-relative URLs ([#243])
+- **Bugfix:** Ignore errors when saving hash history state if
+  `window.sessionStorage` is undefined ([#295])
 
 [HEAD]: https://github.com/mjackson/history/compare/v3.0.0-2...HEAD
 [#243]: https://github.com/mjackson/history/issues/243
+[#295]: https://github.com/mjackson/history/issues/295
 
 ## [v3.0.0-2]
 > Apr 19, 2016

--- a/modules/DOMStateStorage.js
+++ b/modules/DOMStateStorage.js
@@ -13,6 +13,16 @@ const createKey = (key) =>
   KeyPrefix + key
 
 export const saveState = (key, state) => {
+  if (!window.sessionStorage) {
+    // Session storage is not available or hidden.
+    // sessionStorage is undefined in Internet Explorer when served via file protocol.
+    warning(
+      false,
+      '[history] Unable to save state; sessionStorage is not available'
+    )
+    return
+  }
+
   try {
     if (state == null) {
       window.sessionStorage.removeItem(createKey(key))


### PR DESCRIPTION
`window.sessionStorage` is undefined in Internet Explorer when served via file protocol.
Ignore the error and return undefined in readState/setState.

Fixes #295 