### PR TITLE
Fix #126: Replacing hash path in IE served via file protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,11 @@
 
 - `location.query` has no prototype
 - Warn about protocol-relative URLs ([#243])
+- **Bugfix:** Fix replacing hash path in IE served via file protocol ([#126])
 
 [HEAD]: https://github.com/mjackson/history/compare/v3.0.0-2...HEAD
 [#243]: https://github.com/mjackson/history/issues/243
+[#126]: https://github.com/mjackson/history/issues/126
 
 ## [v3.0.0-2]
 > Apr 19, 2016

--- a/modules/HashProtocol.js
+++ b/modules/HashProtocol.js
@@ -26,7 +26,7 @@ const pushHashPath = (path) =>
 
 const replaceHashPath = (path) =>
   window.location.replace(
-    window.location.pathname + window.location.search + '#' + path
+    '#' + path
   )
 
 const ensureSlash = () => {


### PR DESCRIPTION
Fixes the issue discussed in #126, where the initial `replaceHashPath` call replaces the current location with a bad location, when the page is served via the the file protocol in IE 11. 

The behaviour *should* be the same as before for other cases.