### PR TITLE
Update createHistory.js

### DIFF
--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -11,6 +11,7 @@ import describeHashSupport from './describeHashSupport'
 import describeBasename from './describeBasename'
 import describeQueries from './describeQueries'
 import describeGo from './describeGo'
+import describeUnlisten from './describeUnlisten'
 
 describe('browser history', function () {
   beforeEach(function () {
@@ -29,6 +30,7 @@ describe('browser history', function () {
     describeBasename(createBrowserHistory)
     describeQueries(createBrowserHistory)
     describeGo(createBrowserHistory)
+    describeUnlisten(createBrowserHistory)
   } else {
     describe.skip(null, function () {
       describeInitialLocation(createBrowserHistory)
@@ -42,6 +44,7 @@ describe('browser history', function () {
       describeBasename(createBrowserHistory)
       describeQueries(createBrowserHistory)
       describeGo(createBrowserHistory)
+      describeUnlisten(createBrowserHistory)
     })
   }
 })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -12,6 +12,7 @@ import describeQueryKey from './describeQueryKey'
 import describeBasename from './describeBasename'
 import describeQueries from './describeQueries'
 import describeGo from './describeGo'
+import describeUnlisten from './describeUnlisten'
 
 describe('hash history', function () {
   beforeEach(function () {
@@ -27,6 +28,7 @@ describe('hash history', function () {
   describeReplace(createHashHistory)
   describeBasename(createHashHistory)
   describeQueries(createHashHistory)
+  describeUnlisten(createHashHistory)
 
   if (supportsHistory()) {
     describePopState(createHashHistory)

--- a/modules/__tests__/describeUnlisten.js
+++ b/modules/__tests__/describeUnlisten.js
@@ -1,0 +1,38 @@
+import expect from 'expect'
+
+function describeUnlisten(createHistory) {
+  describe('location never has stale path', function () {
+    let unlisten, history
+    beforeEach(function () {
+      history = createHistory()
+    })
+
+    afterEach(function () {
+      if (unlisten)
+        unlisten()
+    })
+
+    it('stale history test', function (done) {
+
+      unlisten = history.listen(function () {
+      })
+
+      history.push({
+        pathname: '/stale',
+        state: { initial: 'state' }
+      })
+
+      unlisten()
+
+      window.history.pushState({ initial: 'state' }, undefined, '/#/notstale')
+
+      unlisten = history.listen(function (location) {
+        expect(location.pathname).toNotEqual('/stale')
+        done()
+      })
+
+    })
+  })
+}
+
+export default describeUnlisten

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -70,13 +70,20 @@ function createHistory(options={}) {
 
   function listen(listener) {
     changeListeners.push(listener)
-    
-    const location = getCurrentLocation()
-    allKeys = [ location.key ]
-    updateLocation(location)
+
+    if (location) {
+      listener(location)
+    } else {
+      const location = getCurrentLocation()
+      allKeys = [ location.key ]
+      updateLocation(location)
+    }
 
     return function () {
       changeListeners = changeListeners.filter(item => item !== listener)
+      if (changeListeners.length === 0) {
+        location = undefined
+      }
     }
   }
 

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -70,14 +70,10 @@ function createHistory(options={}) {
 
   function listen(listener) {
     changeListeners.push(listener)
-
-    if (location) {
-      listener(location)
-    } else {
-      const location = getCurrentLocation()
-      allKeys = [ location.key ]
-      updateLocation(location)
-    }
+    
+    const location = getCurrentLocation()
+    allKeys = [ location.key ]
+    updateLocation(location)
 
     return function () {
       changeListeners = changeListeners.filter(item => item !== listener)

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -82,7 +82,7 @@ function createHistory(options={}) {
     return function () {
       changeListeners = changeListeners.filter(item => item !== listener)
       if (changeListeners.length === 0) {
-        location = undefined
+        location = null
       }
     }
   }


### PR DESCRIPTION
When using this library, my coworker and I ran into a problem with the location being stale. After creating history we would need to turn off the event listeners, and then at a later point re-enable the history and event listeners. Unfortunately, when the listen function ran after re-enabling history `location` was the url of when we disabled history rather than being reflective of the current url. By running `getCurrentLocation` on each listen the location is always current.