### PR TITLE
Fix key for new locations with hash history

### DIFF
--- a/modules/HashProtocol.js
+++ b/modules/HashProtocol.js
@@ -92,6 +92,8 @@ const updateLocation = (location, pathCoder, queryKey, updateHash) => {
   if (state !== undefined) {
     path = addQueryStringValueToPath(path, queryKey, key)
     saveState(key, state)
+  } else {
+    location.key = null
   }
 
   prevLocation = location

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -42,12 +42,12 @@ describe('hash history', () => {
 
   if (supportsHistory() && supportsGoWithoutReloadUsingHash()) {
     describeGo(createHashHistory)
-    describeQueryKey(createHashHistory)
+    describeQueryKey(createHashHistory, () => window.location.hash.slice(1))
     describePathCoding(createHashHistory)
   } else {
     describe.skip('go without reload not supported', () => {
       describeGo(createHashHistory)
-      describeQueryKey(createHashHistory)
+      describeQueryKey(createHashHistory, () => window.location.hash.slice(1))
       describePathCoding(createHashHistory)
     })
   }

--- a/modules/__tests__/describeBasename.js
+++ b/modules/__tests__/describeBasename.js
@@ -33,7 +33,6 @@ const describeBasename = (createHistory) => {
             expect(location.search).toEqual('')
             expect(location.state).toBe(undefined)
             expect(location.action).toEqual(PUSH)
-            expect(location.key).toExist()
             expect(location.basename).toEqual('/base/url')
           }
         ]
@@ -101,7 +100,6 @@ const describeBasename = (createHistory) => {
             expect(location.search).toEqual('')
             expect(location.state).toBe(undefined)
             expect(location.action).toEqual(REPLACE)
-            expect(location.key).toExist()
             expect(location.basename).toEqual('/base/url')
           }
         ]

--- a/modules/__tests__/describePush.js
+++ b/modules/__tests__/describePush.js
@@ -5,8 +5,17 @@ import execSteps from './execSteps'
 const describePush = (createHistory) => {
   describe('push', () => {
     let history
+    let unlisten
+
     beforeEach(() => {
       history = createHistory()
+      unlisten = null
+    })
+
+    afterEach(() => {
+      if (unlisten) {
+        unlisten()
+      }
     })
 
     describe('with a path string', () => {
@@ -30,6 +39,18 @@ const describePush = (createHistory) => {
         ]
 
         execSteps(steps, history, done)
+      })
+
+      it('should trigger listener only once', (done) => {
+        const spy = expect.createSpy()
+        unlisten = history.listen(spy)
+
+        history.push('/test')
+
+        setTimeout(() => {
+          expect(spy.calls.length).toBe(1)
+          done()
+        })
       })
     })
 

--- a/modules/__tests__/describePush.js
+++ b/modules/__tests__/describePush.js
@@ -26,7 +26,6 @@ const describePush = (createHistory) => {
             expect(location.search).toEqual('?the=query')
             expect(location.state).toBe(undefined)
             expect(location.action).toEqual(PUSH)
-            expect(location.key).toExist()
           }
         ]
 

--- a/modules/__tests__/describeQueryKey.js
+++ b/modules/__tests__/describeQueryKey.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import { PUSH, POP } from '../Actions'
 import execSteps from './execSteps'
 
-const describeQueryKey = (createHistory) => {
+const describeQueryKey = (createHistory, getFullPath) => {
   describe('when queryKey == "a"', () => {
     let history
     beforeEach(() => {
@@ -17,6 +17,7 @@ const describeQueryKey = (createHistory) => {
           expect(location.state).toBe(undefined)
           expect(location.action).toEqual(POP)
           expect(location.key).toBe(null)
+          expect(getFullPath()).toEqual('/')
 
           history.push({
             pathname: '/home',
@@ -30,6 +31,7 @@ const describeQueryKey = (createHistory) => {
           expect(location.state).toEqual({ the: 'state' })
           expect(location.action).toEqual(PUSH)
           expect(location.key).toExist()
+          expect(getFullPath()).toEqual(`/home?the=query&a=${location.key}`)
 
           history.goBack()
         },
@@ -39,6 +41,7 @@ const describeQueryKey = (createHistory) => {
           expect(location.state).toBe(undefined)
           expect(location.action).toEqual(POP)
           expect(location.key).toBe(null)
+          expect(getFullPath()).toEqual('/')
 
           history.goForward()
         },
@@ -48,6 +51,19 @@ const describeQueryKey = (createHistory) => {
           expect(location.state).toEqual({ the: 'state' }) // State is present
           expect(location.action).toEqual(POP)
           expect(location.key).toExist()
+          expect(getFullPath()).toEqual(`/home?the=query&a=${location.key}`)
+
+          history.push('/')
+        },
+        (location) => {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toBe(undefined)
+          expect(location.action).toEqual(PUSH)
+          expect(location.key).toBe(null)
+          expect(getFullPath()).toEqual('/')
+
+          history.goForward()
         }
       ]
 


### PR DESCRIPTION
The new test case demonstrates the issue. When you do `hashHistory.push()`, the new location has a `key`, but there's no query key and you can never recover that key again; it ends up being a purely in-memory thing.

This code isn't wonderful but it's the best I could find without a more extensive refactor.