### PR TITLE
ReferenceError: window is not defined

### DIFF
--- a/modules/BrowserProtocol.js
+++ b/modules/BrowserProtocol.js
@@ -7,7 +7,7 @@ import {
 import { saveState, readState } from './DOMStateStorage'
 import { createPath } from './PathUtils'
 
-import { canUseDOM } from './ExecutionEnvironment';
+import { canUseDOM } from './ExecutionEnvironment'
 
 const PopStateEvent = 'popstate'
 const HashChangeEvent = 'hashchange'

--- a/modules/BrowserProtocol.js
+++ b/modules/BrowserProtocol.js
@@ -7,10 +7,12 @@ import {
 import { saveState, readState } from './DOMStateStorage'
 import { createPath } from './PathUtils'
 
+import { canUseDOM } from './ExecutionEnvironment';
+
 const PopStateEvent = 'popstate'
 const HashChangeEvent = 'hashchange'
 
-const needsHashchangeListener = !supportsPopstateOnHashchange()
+const needsHashchangeListener = canUseDOM && !supportsPopstateOnHashchange()
 
 const _createLocation = (historyState) => {
   const key = historyState && historyState.key


### PR DESCRIPTION
After an upgrade to history@3.2.0 I started getting the error below. This is happening because this function is being called: https://github.com/mjackson/history/blob/1370f889784c01d3a16c192e5c1a052310e20a4d/modules/BrowserProtocol.js#L13 in a server context (where "window" is not defined).

    [2] [dev:server] /Users/shripadk/test/node_modules/history/lib/DOMUtils.js:39
    [2]   return window.navigator.userAgent.indexOf('Trident') === -1;
    [2]          ^
    [2] [dev:server] ReferenceError: window is not defined
    [2]     at supportsPopstateOnHashchange (/Users/shripadk/test/node_modules/history/lib/DOMUtils.js:39:10)
    [2]     at Object.<anonymous> (/Users/shripadk/test/node_modules/history/lib/BrowserProtocol.js:17:75)
    [2]     at Module._compile (module.js:556:32)
    [2]     at Object.Module._extensions..js (module.js:565:10)
    [2]     at Module.load (module.js:473:32)
    [2]     at tryModuleLoad (module.js:432:12)
    [2]     at Function.Module._load (module.js:424:3)
    [2]     at Module.require (module.js:483:17)
    [2]     at require (internal/module.js:20:19)
    [2]     at Object.<anonymous> (/Users/shripadk/test/node_modules/history/lib/createBrowserHistory.js:13:24)
