### PR TITLE
fix the link of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ history.push({
 unlisten()
 ```
 
-You can find many more examples [in the documentation](https://github.com/mjackson/history/tree/master/docs)!
+You can find many more examples [in the documentation](https://github.com/mjackson/history/tree/v2.x/docs)!
 
 ## Thanks
 


### PR DESCRIPTION
The link of v2.x's documentation is incorrect after the release of v4.x, which is inconvenient to look up the previous docs.