### PR TITLE
Add in doc another helpful usage of createMemoryHistory that was very…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can find the library on `window.History`.
 `history` provides 3 different methods for creating a `history` object, depending on your environment.
 
 - `createBrowserHistory` is for use in modern web browsers that support the [HTML5 history API](http://diveintohtml5.info/history.html) (see [cross-browser compatibility](http://caniuse.com/#feat=history))
-- `createMemoryHistory` is used as a reference implementation and may also be used in non-DOM environments, like [React Native](https://facebook.github.io/react-native/)
+- `createMemoryHistory` is used as a reference implementation and may also be used in non-DOM environments, like [React Native](https://facebook.github.io/react-native/), unit-tests or server-side rendering. It can also be useful for [Cordova](https://cordova.apache.org/) applications, if you need the url to stay on Cordova's `index.html` in this specific environment, while your mobile website is already using `createBrowserHistory`
 - `createHashHistory` is for use in legacy web browsers
 
 Depending on the method you want to use to keep track of history, you'll `import` (or `require`) one of these methods directly from the package root (i.e. `history/createBrowserHistory`). The remainder of this document uses the term `createHistory` to refer to any of these implementations.
@@ -122,7 +122,8 @@ The `location` object implements a subset of [the `window.location` interface](h
 
 Locations may also have the following properties:
 
-- `location.state` - Some extra state for this location that does not reside in the URL (supported in `createBrowserHistory` and `createMemoryHistory`)
+- `location.state` - Some extra state for this location that does not reside in the URL (supported in `createBrowserHistory` and `
+`)
 - `location.key` - A unique string representing this location (supported in `createBrowserHistory` and `createMemoryHistory`)
 
 The `action` is one of `PUSH`, `REPLACE`, or `POP` depending on how the user got to the current URL.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ The `location` object implements a subset of [the `window.location` interface](h
 
 Locations may also have the following properties:
 
-- `location.state` - Some extra state for this location that does not reside in the URL (supported in `createBrowserHistory` and `
-`)
+- `location.state` - Some extra state for this location that does not reside in the URL (supported in `createBrowserHistory` and `createMemoryHistory`)
 - `location.key` - A unique string representing this location (supported in `createBrowserHistory` and `createMemoryHistory`)
 
 The `action` is one of `PUSH`, `REPLACE`, or `POP` depending on how the user got to the current URL.


### PR DESCRIPTION
… helpful for me

If you have a mobile website, that is also shipped as a Cordova app, and both have the same codebase, the Cordova app can use memory history, while the mobile website can use real browser history.
This way, the cordova app can stay on index.html of Cordova (which can be required for some UX/features, see https://github.com/EddyVerbruggen/Custom-URL-scheme/issues/206#issuecomment-252182327)
