### PR TITLE
Fix the back button in Chrome iOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## HEAD
+> Nov 1, 2016
+
+- Fix the back button on Chrome iOS
+
 ## [v4.4.0]
 > Nov 1, 2016
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,4 @@
 ## HEAD
-> Nov 1, 2016
 
 - Fix the back button on Chrome iOS
 

--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -43,3 +43,12 @@ export const supportsPopStateOnHashChange = () =>
  */
 export const supportsGoWithoutReloadUsingHash = () =>
   window.navigator.userAgent.indexOf('Firefox') === -1
+
+/**
+ * Returns true if a given popstate event is an extraneous WebKit event.
+ * Accounts for the fact that Chrome on iOS fires real popstate events
+ * containing undefined state when pressing the back button.
+ */
+export const isExtraneousPopstateEvent = event =>
+  event.state === undefined &&
+  navigator.userAgent.indexOf('CriOS') === -1

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -9,7 +9,8 @@ import {
   removeEventListener,
   getConfirmation,
   supportsHistory,
-  supportsPopStateOnHashChange
+  supportsPopStateOnHashChange,
+  isExtraneousPopstateEvent
 } from './DOMUtils'
 
 const PopStateEvent = 'popstate'
@@ -79,8 +80,9 @@ const createBrowserHistory = (props = {}) => {
   }
 
   const handlePopState = (event) => {
-    if (event.state === undefined)
-      return // Ignore extraneous popstate events in WebKit.
+    // Ignore extraneous popstate events in WebKit.
+    if (isExtraneousPopstateEvent(event))
+      return 
 
     handlePop(getDOMLocation(event.state))
   }


### PR DESCRIPTION
When pressing the back button in Chrome iOS after the first `pushState`, the `popstate` event contains an `undefined` state (Chrome desktop's `state` value is `null`). This is indistinguishable from an extraneous WebKit `popstate` event, which means that `handlePop` and the `history` listener never get called.

This adds a UA check for CriOS to distinguish between bogus WebKit `popstate` events and real Chrome iOS ones.

I didn't add a test for this, as it appears that the DOM/UA-specific stuff isn't unit tested. Happy to add one if you like!

BrowserStack now [supports Chrome iOS](https://www.browserstack.com/newsletter-chrome-on-ios?utm_campaign=chrome-ios&utm_medium=email&utm_source=newsletter-chrome-ios-may2016), so it might be worth adding it to the testing matrix.

If you'd like to replicate this yourself, you'll have to use [`weinre`](https://people.apache.org/~pmuellr/weinre/docs/latest/Home.html) to debug against Chrome iOS. Not the best situation there 😄 