### PR TITLE
Ensure that the provided `basename` starts with a forward slash `/`

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import invariant from 'invariant'
 import { createLocation } from './LocationUtils'
-import { stripPrefix, parsePath, createPath } from './PathUtils'
+import { addLeadingSlash, stripPrefix, parsePath, createPath } from './PathUtils'
 import createTransitionManager from './createTransitionManager'
 import { canUseDOM } from './ExecutionEnvironment'
 import {
@@ -41,11 +41,11 @@ const createBrowserHistory = (props = {}) => {
   const needsHashChangeListener = !supportsPopStateOnHashChange()
 
   const {
-    basename = '',
     forceRefresh = false,
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props
+  const basename = props.basename ? addLeadingSlash(props.basename) : ''
 
   const getDOMLocation = (historyState) => {
     const { key, state } = (historyState || {})

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -57,10 +57,10 @@ const createHashHistory = (props = {}) => {
   const canGoWithoutReload = supportsGoWithoutReloadUsingHash()
 
   const {
-    basename = '',
     getUserConfirmation = getConfirmation,
     hashType = 'slash'
   } = props
+  const basename = props.basename ? addLeadingSlash(props.basename) : ''
 
   const { encodePath, decodePath } = HashPathCoders[hashType]
 


### PR DESCRIPTION
I was going to add a unit test for this, but noticed that adding proper unit tests for `basename` would be a lot more work than just adding one new test for this change, so this PR does not include new tests.  All existing tests still pass though.

I also had to break out `basename` from the destructuring assignment, which isn't as nice looking.  Let me know if you prefer this done a different way though.